### PR TITLE
Prevent double memory freeing problem

### DIFF
--- a/TDAudioPlayer/AudioPlayerLibrary/AudioStreamer/Classes/TDAudioQueue.m
+++ b/TDAudioPlayer/AudioPlayerLibrary/AudioStreamer/Classes/TDAudioQueue.m
@@ -43,7 +43,6 @@ void TDAudioQueueOutputCallback(void *inUserData, AudioQueueRef inAudioQueue, Au
     self.bufferManager = [[TDAudioQueueBufferManager alloc] initWithAudioQueue:self.audioQueue size:bufferSize count:bufferCount];
 
     AudioQueueSetProperty(self.audioQueue, kAudioQueueProperty_MagicCookie, magicCookieData, magicCookieSize);
-    free(magicCookieData);
 
     AudioQueueSetParameter(self.audioQueue, kAudioQueueParam_Volume, 1.0);
 


### PR DESCRIPTION
Removing the free of the magic cookie memory from here, as this class does not own the memory and it is free'd on the dealloc of TDAudioFileStream which allocated the memory. Having the free here as well causes an attempted double deallocation.