### PR TITLE
Thread release and play end of buffer

### DIFF
--- a/TDAudioPlayer/AudioPlayerLibrary/AudioStreamer/TDAudioInputStreamer.m
+++ b/TDAudioPlayer/AudioPlayerLibrary/AudioStreamer/TDAudioInputStreamer.m
@@ -86,7 +86,7 @@
 
         self.isPlaying = YES;
 
-        while (self.isPlaying && [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]) ;
+        while (self.isPlaying && [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25]]) ;
     }
 }
 
@@ -129,7 +129,6 @@
         }
 
         case TDAudioStreamEventEnd:
-            self.isPlaying = NO;
             [self.audioQueue finish];
             break;
 
@@ -155,6 +154,7 @@
 
 - (void)audioFileStream:(TDAudioFileStream *)audioFileStream didReceiveError:(OSStatus)error
 {
+    self.isPlaying = NO;
     [[NSNotificationCenter defaultCenter] postNotificationName:TDAudioStreamDidFinishPlayingNotification object:nil];
 }
 
@@ -172,6 +172,7 @@
 
 - (void)audioQueueDidFinishPlaying:(TDAudioQueue *)audioQueue
 {
+    self.isPlaying = NO;
     [self performSelectorOnMainThread:@selector(notifyMainThread:) withObject:TDAudioStreamDidFinishPlayingNotification waitUntilDone:NO];
 }
 
@@ -182,7 +183,7 @@
 
 - (void)notifyMainThread:(NSString *)notificationName
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:self];
 }
 
 #pragma mark - Public Methods


### PR DESCRIPTION
Change the run loop termination condition so when there is nothing to do it will exit - otherwise the thread sits there after the stream plays doing nothing, using up resources.
Removing self.isPlaying = NO from the TDAudioStreamEventEnd handling as that is just the end of the stream - the queue still has buffered data to play, so the stream is still playing. [self.audioQueue finish] instructs it to flush out the rest of the queued data and then stop.
Adding self.isPlaying = NO; to the error handler and audioQueueDidFinishPlaying, the latter of which is called when the queue runs out of data to play and the stream is really finished.
Making the notifications come from the self object rather than nil - makes no difference if you were listening to nil (ie all) but enables differentiation of the stream you are listening too.